### PR TITLE
Remove debounce to handle values updated simultaneously

### DIFF
--- a/index.js
+++ b/index.js
@@ -93,7 +93,6 @@ module.exports = function (app) {
     // Setup SignalK delta subscription
     plugin.onStop.push(app.streambundle
       .getBus()
-      .debounceImmediate(500)
       .onValue(handleDelta));
   };
 


### PR DESCRIPTION
Thanks for the great plugin. 

However, I think I encountered a bug. When several values get updated simultaneously (for example, because they are generated by the same NMEA sentence or the same derived-data plugin), only the first value was being processed by this plugin.

For example, my battery monitor outputs a sentence that updates several SignalK values at once. However, the plugin was only picking up the first delta:

> signalk-mqtt-bridge Got delta for topic vessels/self/electrical/batteries/0/voltage +841ms

But if I remove the debounce, finds all of the deltas:

>  signalk-mqtt-bridge Got delta for topic vessels/self/electrical/batteries/0/voltage +841ms
>  signalk-mqtt-bridge Got delta for topic vessels/self/electrical/batteries/0/current +2ms
>  signalk-mqtt-bridge Got delta for topic vessels/self/electrical/batteries/0/capacity/stateOfCharge +3ms