### PR TITLE
Buffer signalk deltas before publishing them to mqtt

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Note that this plugin doesn't have an embedded MQTT broker. It connects as a cli
 - [Scoped MQTT topics](#scoped-mqtt-topics)
 - [Keepalive mechanism](#keepalive) to avoid unnecessary load on the MQTT broker
 - [Send SignalK deltas to MQTT](#subscribe-to-signalk-deltas)
+- [Buffered publishing](#buffered-publishing) to reduce broker load from high-frequency sensors
 - [Request specific SignalK paths from MQTT](#request-signalk-data-from-mqtt)
 - [Push deltas to SignalK from MQTT](#send-deltas-to-signalk-via-mqtt)
 - [Send PUT requests to SignalK from MQTT](#send-put-requests-to-signalk-via-mqtt)
@@ -68,6 +69,12 @@ mosquitto_sub -t 'N/signalk/4881db477e55/vessels/self/#'
 # in a separate terminal
 while :; do mosquitto_pub -m '["vessels/self/#"]' -t 'R/signalk/4881db477e55/keepalive'; sleep 30; done
 ```
+
+## Buffered publishing
+
+By default, incoming SignalK deltas are not published to MQTT immediately. Instead, they are held in an in-memory buffer and flushed to the broker on a regular interval (10 seconds by default). When multiple updates arrive for the same topic before the flush, only the latest value is kept (last-write-wins), reducing redundant messages for high-frequency sensors.
+
+The interval is controlled by the `publishInterval` option in the plugin configuration (in seconds). Setting it to `0` or a negative value disables buffering entirely and publishes each delta immediately as it arrives.
 
 ## Request SignalK data from MQTT
 

--- a/index.js
+++ b/index.js
@@ -32,6 +32,11 @@ module.exports = function (app) {
         type: 'number',
         title: 'TTL of the MQTT keepalive in seconds',
         default: 60
+      },
+      publishInterval: {
+        type: 'number',
+        title: 'How often to publish buffered deltas to MQTT (in seconds). Set to 0 or less to publish immediately without buffering.',
+        default: 10
       }
     }
   };
@@ -53,9 +58,12 @@ module.exports = function (app) {
     }
 
     plugin.keepaliveTtl = parseInt(options.keepaliveTtl) || plugin.schema.properties.keepaliveTtl.default;
+    const parsedInterval = parseFloat(options.publishInterval);
+    plugin.publishInterval = isNaN(parsedInterval) ? plugin.schema.properties.publishInterval.default : parsedInterval;
 
     // Initialize delta subscriptions
     plugin.subscriptions = [];
+    plugin.deltaBuffer = new Map(); // topic → message (last-write-wins)
 
     // Connect to mqtt broker
     plugin.client = mqtt.connect(options.mqttBrokerAddress, {
@@ -94,6 +102,23 @@ module.exports = function (app) {
       plugin.onStop.push(() => {
         clearInterval(plugin.expireSubscriptionsInterval);
         plugin.expireSubscriptionsInterval = undefined;
+      });
+    }
+
+    // Flush buffered deltas to MQTT on a configurable interval
+    if (plugin.publishInterval > 0) {
+      plugin.publishIntervalTimer = setInterval(() => {
+        if (plugin.deltaBuffer.size === 0) return;
+        plugin.deltaBuffer.forEach((message, topic) => {
+          publishMqtt(topic, message);
+        });
+        plugin.deltaBuffer.clear();
+      }, plugin.publishInterval * 1000);
+
+      plugin.onStop.push(() => {
+        clearInterval(plugin.publishIntervalTimer);
+        plugin.publishIntervalTimer = undefined;
+        plugin.deltaBuffer = new Map();
       });
     }
 
@@ -200,10 +225,13 @@ module.exports = function (app) {
       return;
     }
 
-    app.debug('Got delta for topic ' + subTopic);
-
-    // Publish message
-    publishMqtt('N/signalk/' + plugin.systemId + '/' + subTopic, signalkDeltaToMqttMessage(delta));
+    if (plugin.publishInterval > 0) {
+      app.debug('Buffering delta for topic ' + subTopic);
+      plugin.deltaBuffer.set('N/signalk/' + plugin.systemId + '/' + subTopic, signalkDeltaToMqttMessage(delta));
+    } else {
+      app.debug('Publishing delta for topic ' + subTopic);
+      publishMqtt('N/signalk/' + plugin.systemId + '/' + subTopic, signalkDeltaToMqttMessage(delta));
+    }
   }
 
   // Handles writes from MQTT into SignalK

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "signalk-mqtt-bridge",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "signalk-mqtt-bridge",
-      "version": "0.3.2",
+      "version": "0.4.0",
       "license": "MIT",
       "dependencies": {
         "mqtt": "^4.3.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "signalk-mqtt-bridge",
-  "version": "0.3.2",
+  "version": "0.4.0",
   "description": "SignalK Node server plugin that acts as a bridge between SignalK data and MQTT",
   "main": "index.js",
   "keywords": [

--- a/test/plugin.test.mjs
+++ b/test/plugin.test.mjs
@@ -49,7 +49,7 @@ describe('signalk-mqtt-bridge', function () {
 
   async function startPlugin(app, options = {}) {
     const plugin = pluginFactory(app);
-    plugin.start({ mqttBrokerAddress: brokerCtx.url, keepaliveTtl: 60, ...options });
+    plugin.start({ mqttBrokerAddress: brokerCtx.url, keepaliveTtl: 60, publishInterval: 1, ...options });
     await waitFor(() => app.setPluginStatus.calledWith('MQTT Connected'));
     return plugin;
   }
@@ -448,6 +448,86 @@ describe('signalk-mqtt-bridge', function () {
       } finally {
         plugin2.stop();
       }
+    });
+  });
+
+  // ---------------------------------------------------------------------------
+  // I. Delta buffering
+  // ---------------------------------------------------------------------------
+
+  describe('I. Delta buffering', function () {
+    let app, plugin;
+
+    beforeEach(async function () {
+      app = createAppMock(SELF_ID);
+      plugin = await startPlugin(app);  // publishInterval: 1 by default
+    });
+
+    afterEach(function () {
+      if (plugin) { plugin.stop(); plugin = null; }
+    });
+
+    it('delta is NOT published immediately while buffered', async function () {
+      await sendKeepalive();
+      messages = [];
+      app._emitDelta(selfDelta('navigation.speedOverGround', 3.5));
+      await delay(500);   // less than 1 s flush interval
+      expect(messages.filter(m => m.topic.includes('navigation/speedOverGround'))).to.be.empty;
+    });
+
+    it('buffered delta IS published after the flush interval', async function () {
+      await sendKeepalive();
+      messages = [];
+      app._emitDelta(selfDelta('navigation.speedOverGround', 3.5));
+      await waitFor(() => messages.some(m => m.topic.includes('navigation/speedOverGround')));
+    });
+
+    it('multiple deltas for same topic: only last value is published (last-write-wins)', async function () {
+      await sendKeepalive();
+      messages = [];
+      app._emitDelta(selfDelta('navigation.speedOverGround', 1.0));
+      app._emitDelta(selfDelta('navigation.speedOverGround', 2.0));
+      app._emitDelta(selfDelta('navigation.speedOverGround', 3.0));
+      await waitFor(() => messages.some(m => m.topic.includes('navigation/speedOverGround')));
+      const published = messages.filter(m => m.topic.includes('navigation/speedOverGround'));
+      expect(published).to.have.length(1);
+      expect(JSON.parse(published[0].payload).value).to.equal(3.0);
+    });
+
+    it('deltas for different topics are all published on flush', async function () {
+      await sendKeepalive();
+      messages = [];
+      app._emitDelta(selfDelta('navigation.speedOverGround', 1.0));
+      app._emitDelta(selfDelta('navigation.headingTrue', 2.0));
+      await waitFor(() =>
+        messages.some(m => m.topic.includes('navigation/speedOverGround')) &&
+        messages.some(m => m.topic.includes('navigation/headingTrue'))
+      );
+    });
+
+    it('publishInterval: 0 publishes immediately without buffering', async function () {
+      plugin.stop();
+      plugin = null;
+      const app2 = createAppMock(SELF_ID);
+      const plugin2 = await startPlugin(app2, { publishInterval: 0 });
+      try {
+        await sendKeepalive();
+        messages = [];
+        app2._emitDelta(selfDelta('navigation.speedOverGround', 3.5));
+        await waitFor(() => messages.some(m => m.topic.includes('navigation/speedOverGround')), 1000);
+      } finally {
+        plugin2.stop();
+      }
+    });
+
+    it('buffered delta is NOT published after plugin is stopped', async function () {
+      await sendKeepalive();
+      messages = [];
+      app._emitDelta(selfDelta('navigation.speedOverGround', 9.9));
+      plugin.stop();
+      plugin = null;
+      await delay(1500);  // wait past where flush would have occurred
+      expect(messages.filter(m => m.topic.includes('navigation/speedOverGround'))).to.be.empty;
     });
   });
 });


### PR DESCRIPTION
Signalk values that get updated very frequently can potentially flood/overload the MQTT broker. To avoid this, the plugin will now buffer incoming deltas and flush them to the broker on a regular interval (10 seconds by default).

When multiple updates arrive for the same topic before the flush, only the latest value is kept (last-write-wins), reducing redundant messages for high-frequency sensors.

The interval is controlled by the `publishInterval` option in the plugin configuration (in seconds). Setting it to `0` or a negative value disables buffering entirely and publishes each delta immediately as it arrives.